### PR TITLE
Remove setting of updatetime

### DIFF
--- a/nerdtree_plugin/highlight_open_buffers.vim
+++ b/nerdtree_plugin/highlight_open_buffers.vim
@@ -23,13 +23,9 @@ function! NERDTreeHighlightOpenBuffers(event)
 endfunction
 
 " Autocmds to trigger NERDTree flag refreshes
-let s:old_updatetime = &updatetime
 augroup NERDTreeHighlightOpenBuffersPlugin
     autocmd CursorHold,BufEnter * silent! call s:RefreshFlags()
-    autocmd BufDelete,BufWipeout * silent! set updatetime=10
-    autocmd BufWritePost,BufReadPost  * silent!
-                \ execute "set updatetime=".s:old_updatetime |
-                \ call s:RefreshFlags()
+    autocmd BufWritePost,BufReadPost  * silent! s:RefreshFlags()
 augroup END
 function! s:RefreshFlags()
     if g:NERDTree.IsOpen() && !exists('s:stop_recursion')

--- a/nerdtree_plugin/highlight_open_buffers.vim
+++ b/nerdtree_plugin/highlight_open_buffers.vim
@@ -23,10 +23,13 @@ function! NERDTreeHighlightOpenBuffers(event)
 endfunction
 
 " Autocmds to trigger NERDTree flag refreshes
+let s:old_updatetime = &updatetime
 augroup NERDTreeHighlightOpenBuffersPlugin
     autocmd CursorHold,BufEnter * silent! call s:RefreshFlags()
     autocmd BufDelete,BufWipeout * silent! set updatetime=10
-    autocmd BufWritePost,BufReadPost  * silent! set updatetime& | call s:RefreshFlags()
+    autocmd BufWritePost,BufReadPost  * silent!
+                \ execute "set updatetime=".s:old_updatetime |
+                \ call s:RefreshFlags()
 augroup END
 function! s:RefreshFlags()
     if g:NERDTree.IsOpen() && !exists('s:stop_recursion')


### PR DESCRIPTION
Fixed #3.

With this pull request, all mentions of the `updatetime` option are removed. This is to make this plugin play nice with others. The use of separate autocommands to change and then reset the setting allowed there to be possible interference.

With no way to guarantee that it's correctly being set, `updatetime` is now left untouched by this plugin.